### PR TITLE
Fix day-specific study hours persistence on page reload

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.kf4j9fii6v8"
+    "revision": "0.6fkdtaga088"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -517,7 +517,9 @@ function App() {
                         userPrefersPressure: parsedSettings.userPrefersPressure || false,
                         studyPlanMode: parsedSettings.studyPlanMode || 'even',
                         dateSpecificStudyWindows: parsedSettings.dateSpecificStudyWindows || [],
-                        daySpecificStudyWindows: parsedSettings.daySpecificStudyWindows || []
+                        daySpecificStudyWindows: parsedSettings.daySpecificStudyWindows || [],
+                        daySpecificStudyHours: parsedSettings.daySpecificStudyHours || [],
+                        showDaySpecificHoursSection: parsedSettings.showDaySpecificHoursSection || false
                     };
                 }
             }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,7 +65,9 @@ function App() {
         userPrefersPressure: false,
         studyPlanMode: 'even',
         dateSpecificStudyWindows: [],
-        daySpecificStudyWindows: []
+        daySpecificStudyWindows: [],
+        daySpecificStudyHours: [],
+        showDaySpecificHoursSection: false
     });
     const [, setIsPlanStale] = useState(false);
     const [, setLastPlanStaleReason] = useState<"settings" | "commitment" | "task" | null>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -483,7 +483,9 @@ function App() {
                 userPrefersPressure: false,
                 studyPlanMode: 'even', // Set default to 'even'
                 dateSpecificStudyWindows: [],
-                daySpecificStudyWindows: []
+                daySpecificStudyWindows: [],
+                daySpecificStudyHours: [],
+                showDaySpecificHoursSection: false
             };
             let initialCommitments: FixedCommitment[] = [];
             let initialStudyPlans: StudyPlan[] = [];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -225,7 +225,9 @@ function App() {
                         userPrefersPressure: false,
                         studyPlanMode: 'even',
                         dateSpecificStudyWindows: [],
-                        daySpecificStudyWindows: []
+                        daySpecificStudyWindows: [],
+                        daySpecificStudyHours: [],
+                        showDaySpecificHoursSection: false
                     };
                     setSettings({ ...defaultSettings, ...parsed });
                 }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -412,18 +412,18 @@ const Settings: React.FC<SettingsProps> = ({
       return;
     }
 
+    let updatedHours;
     // Check if hours for this day already exists
     const existingIndex = daySpecificStudyHours.findIndex(hours => hours.dayOfWeek === newDayHoursDayOfWeek);
 
     if (existingIndex !== -1) {
       // Update existing hours
-      const updatedHours = [...daySpecificStudyHours];
+      updatedHours = [...daySpecificStudyHours];
       updatedHours[existingIndex] = {
         dayOfWeek: newDayHoursDayOfWeek,
         studyHours: newDayHoursStudyHours,
         isActive: true
       };
-      setDaySpecificStudyHours(updatedHours);
     } else {
       // Add new day-specific hours
       const newHours: DaySpecificStudyHours = {
@@ -431,8 +431,27 @@ const Settings: React.FC<SettingsProps> = ({
         studyHours: newDayHoursStudyHours,
         isActive: true
       };
-      setDaySpecificStudyHours([...daySpecificStudyHours, newHours]);
+      updatedHours = [...daySpecificStudyHours, newHours];
     }
+
+    setDaySpecificStudyHours(updatedHours);
+
+    // Immediately save the changes
+    onUpdateSettings({
+      ...settings,
+      dailyAvailableHours,
+      workDays,
+      bufferDays,
+      minSessionLength,
+      bufferTimeBetweenSessions,
+      studyWindowStartHour,
+      studyWindowEndHour,
+      studyPlanMode,
+      dateSpecificStudyWindows,
+      daySpecificStudyWindows,
+      daySpecificStudyHours: updatedHours,
+      showDaySpecificHoursSection
+    });
 
     // Reset form
     setShowDaySpecificHoursForm(false);
@@ -451,6 +470,23 @@ const Settings: React.FC<SettingsProps> = ({
   const handleDeleteDaySpecificHours = (dayOfWeek: number) => {
     const updatedHours = daySpecificStudyHours.filter(hours => hours.dayOfWeek !== dayOfWeek);
     setDaySpecificStudyHours(updatedHours);
+
+    // Immediately save the changes
+    onUpdateSettings({
+      ...settings,
+      dailyAvailableHours,
+      workDays,
+      bufferDays,
+      minSessionLength,
+      bufferTimeBetweenSessions,
+      studyWindowStartHour,
+      studyWindowEndHour,
+      studyPlanMode,
+      dateSpecificStudyWindows,
+      daySpecificStudyWindows,
+      daySpecificStudyHours: updatedHours,
+      showDaySpecificHoursSection
+    });
   };
 
   const handleToggleDayHoursActive = (dayOfWeek: number) => {
@@ -460,6 +496,23 @@ const Settings: React.FC<SettingsProps> = ({
         : hours
     );
     setDaySpecificStudyHours(updatedHours);
+
+    // Immediately save the changes
+    onUpdateSettings({
+      ...settings,
+      dailyAvailableHours,
+      workDays,
+      bufferDays,
+      minSessionLength,
+      bufferTimeBetweenSessions,
+      studyWindowStartHour,
+      studyWindowEndHour,
+      studyPlanMode,
+      dateSpecificStudyWindows,
+      daySpecificStudyWindows,
+      daySpecificStudyHours: updatedHours,
+      showDaySpecificHoursSection
+    });
   };
 
   const formatTimeDisplay = (hour: number): string => {

--- a/test-persistence.md
+++ b/test-persistence.md
@@ -1,0 +1,26 @@
+# Test Day-Specific Study Hours Persistence
+
+## Issue
+Day-specific study hours were not being saved when the page was reloaded.
+
+## Root Causes Found
+1. **Missing fields in default settings** - `daySpecificStudyHours` and `showDaySpecificHoursSection` were missing from default settings objects in App.tsx
+2. **No auto-save for day-specific hours operations** - Adding, deleting, or toggling day-specific hours only updated local state but didn't trigger an immediate save to localStorage
+
+## Fixes Applied
+1. Added `daySpecificStudyHours: []` and `showDaySpecificHoursSection: false` to all default settings objects in App.tsx
+2. Modified day-specific hours handlers in Settings.tsx to immediately call `onUpdateSettings()` after state changes
+3. Updated the settings parsing logic to handle the new fields when loading from localStorage
+
+## Test Instructions
+1. Go to Settings tab
+2. Toggle on "Day-Specific Study Hours" section 
+3. Add a day-specific study hour setting (e.g., Monday: 8 hours)
+4. Reload the page
+5. Go back to Settings
+6. Verify the day-specific hours are still there and the section is still expanded
+
+The fix ensures that:
+- Day-specific study hours are immediately saved when added/edited/deleted
+- The toggle state for showing the day-specific hours section persists
+- Page reloads correctly restore all day-specific hour settings


### PR DESCRIPTION
## Changes Made

### App.tsx
- Added missing `daySpecificStudyHours: []` and `showDaySpecificHoursSection: false` fields to all default settings objects
- Updated settings parsing logic to handle the new fields when loading from localStorage

### Settings.tsx
- Modified `handleSaveDaySpecificHours()` to immediately call `onUpdateSettings()` after updating state
- Updated `handleDeleteDaySpecificHours()` to immediately save changes to localStorage
- Updated `handleToggleDayHoursActive()` to immediately save changes to localStorage

### Service Worker
- Updated revision hash for `index.html` from `0.kf4j9fii6v8` to `0.6fkdtaga088`

### Documentation
- Added `test-persistence.md` file documenting the issue, root causes, fixes, and test instructions

## Summary
This fix ensures that day-specific study hours and the section toggle state are properly persisted across page reloads by adding immediate save operations and including the missing fields in default settings objects.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d518e5b32ce5402bae712b4eb36e7ffb/stellar-haven)

👀 [Preview Link](https://d518e5b32ce5402bae712b4eb36e7ffb-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d518e5b32ce5402bae712b4eb36e7ffb</projectId>-->
<!--<branchName>stellar-haven</branchName>-->